### PR TITLE
Add mobile SDKs and JSON license API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Simple DRM Demo
 
 This repository contains a minimal example of a DRM-like workflow using C++ for
-content encryption and a license server, plus a browser script that fetches a
-key and decrypts video using the Web Crypto API.
+content encryption and a license server, plus client code that fetches a key and
+decrypts video. The license server accepts a JSON request containing a
+`content_id` and responds with a base64-encoded license similar to real DRM
+systems such as Widevine.
 
 ## Build
 
@@ -11,7 +13,7 @@ key and decrypts video using the Web Crypto API.
 g++ -std=c++17 src/encrypt_video.cpp -lcrypto -o encrypt_video
 ./encrypt_video input.mp4 encrypted.mp4 sample.key
 
-# start license server (serves `sample.key` for content_id=sample)
+# start license server (serves `sample.key` for `content_id=sample`)
 g++ -std=c++17 src/license_server.cpp -Iinclude -pthread -lssl -lcrypto -o license_server
 ./license_server
 ```
@@ -21,6 +23,14 @@ g++ -std=c++17 src/license_server.cpp -Iinclude -pthread -lssl -lcrypto -o licen
 Serve the `web/` directory (for example with `python3 -m http.server`), and
 open `index.html` in a browser. It will request the key from the license server
 and decrypt `encrypted.mp4` for playback.
+
+## Mobile SDKs
+
+The `sdk/` directory contains simple clients for requesting licenses from the
+demo server:
+
+- `sdk/kotlin` provides a Kotlin helper suitable for Android projects.
+- `sdk/dart` provides a Dart helper for Flutter applications.
 
 This code is for educational purposes and omits many production considerations
 that real DRM systems like Widevine include.

--- a/sdk/dart/lib/license_client.dart
+++ b/sdk/dart/lib/license_client.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Simple client that requests a license from the demo server.
+class LicenseClient {
+  final Uri server;
+
+  LicenseClient(String serverUrl) : server = Uri.parse(serverUrl);
+
+  Future<List<int>> requestLicense(String contentId) async {
+    final httpClient = HttpClient();
+    final request = await httpClient.postUrl(server.resolve('/license'));
+    request.headers.contentType = ContentType.json;
+    request.write(jsonEncode({'content_id': contentId}));
+
+    final response = await request.close();
+    if (response.statusCode != 200) {
+      throw HttpException('Server returned ${response.statusCode}');
+    }
+    final body = await response.transform(utf8.decoder).join();
+    final map = jsonDecode(body) as Map<String, dynamic>;
+    return base64Decode(map['license'] as String);
+  }
+}

--- a/sdk/kotlin/src/main/kotlin/com/example/drm/LicenseClient.kt
+++ b/sdk/kotlin/src/main/kotlin/com/example/drm/LicenseClient.kt
@@ -1,0 +1,33 @@
+package com.example.drm
+
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
+
+/**
+ * Simple client that requests a license from the demo server.
+ */
+object LicenseClient {
+    @Throws(IOException::class)
+    fun requestLicense(serverUrl: String, contentId: String): ByteArray {
+        val url = URL("$serverUrl/license")
+        val json = "{\"content_id\":\"$contentId\"}"
+
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.doOutput = true
+        conn.setRequestProperty("Content-Type", "application/json")
+        conn.outputStream.use { it.write(json.toByteArray()) }
+
+        if (conn.responseCode != 200) {
+            throw IOException("Server returned ${'$'}{conn.responseCode}")
+        }
+
+        val response = conn.inputStream.bufferedReader().use { it.readText() }
+        val match = Regex("\"license\"\\s*:\\s*\"([^\"]+)\"").find(response)
+            ?: throw IOException("Invalid response: $response")
+        val b64 = match.groupValues[1]
+        return Base64.getDecoder().decode(b64)
+    }
+}

--- a/src/license_server.cpp
+++ b/src/license_server.cpp
@@ -19,7 +19,18 @@ int main() {
     });
 
     svr.Post("/license", [](const httplib::Request& req, httplib::Response& res){
-        auto cid = req.get_param_value("content_id");
+        auto body = req.body;
+        auto pos = body.find("\"content_id\"");
+        if (pos == std::string::npos) {
+            res.status = 400;
+            res.set_content("missing content_id", "text/plain");
+            return;
+        }
+        pos = body.find(':', pos);
+        pos = body.find('"', pos);
+        auto end = body.find('"', pos + 1);
+        std::string cid = body.substr(pos + 1, end - pos - 1);
+
         std::string key_data = load_file(cid + ".key");
         if (key_data.empty()) {
             res.status = 404;
@@ -28,7 +39,8 @@ int main() {
         }
         res.set_header("Access-Control-Allow-Origin", "*");
         res.set_header("Access-Control-Allow-Headers", "*");
-        res.set_content(key_data, "application/octet-stream");
+        std::string b64 = httplib::detail::base64_encode(key_data);
+        res.set_content("{\"license\":\"" + b64 + "\"}", "application/json");
     });
     std::cout << "License server running on http://localhost:8080\n";
     svr.listen("127.0.0.1", 8080);

--- a/web/player.js
+++ b/web/player.js
@@ -1,8 +1,13 @@
 async function loadAndPlay(videoElement, contentId) {
-  const licenseResp = await fetch('http://localhost:8080/license?content_id=' + encodeURIComponent(contentId), {method:'POST'});
-  const keyBuf = await licenseResp.arrayBuffer();
-  const key = keyBuf.slice(0,16);
-  const iv = keyBuf.slice(16,32);
+  const licenseResp = await fetch('http://localhost:8080/license', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({content_id: contentId})
+  });
+  const {license} = await licenseResp.json();
+  const keyBytes = Uint8Array.from(atob(license), c => c.charCodeAt(0));
+  const key = keyBytes.slice(0,16);
+  const iv = keyBytes.slice(16,32);
 
   const encResp = await fetch('encrypted.mp4');
   const encData = await encResp.arrayBuffer();


### PR DESCRIPTION
## Summary
- Extend license server to accept JSON requests and return base64 licenses
- Update web player to decode JSON license
- Add Kotlin and Dart SDKs for retrieving licenses

## Testing
- `g++ -std=c++17 src/license_server.cpp -Iinclude -pthread -lssl -lcrypto -o license_server`
- `kotlin-compiler/kotlinc/bin/kotlinc sdk/kotlin/src/main/kotlin/com/example/drm/LicenseClient.kt -include-runtime -d sdk/kotlin/license-client.jar`
- `dart-sdk/dart-sdk/bin/dart format sdk/dart/lib/license_client.dart`
- `dart-sdk/dart-sdk/bin/dart analyze sdk/dart`


------
https://chatgpt.com/codex/tasks/task_e_689b71c39efc8326a223922ac438cb6c